### PR TITLE
fix broken links[HSTN-895]

### DIFF
--- a/examples/influxdb-enterprise/README.md
+++ b/examples/influxdb-enterprise/README.md
@@ -1,6 +1,6 @@
 # InfluxDB Enterprise Example
 
-This folder shows an example of Terraform code that uses the [influxdb-cluster](https://github.com/gruntwork-io/terraform-aws-influx/tree/master/modules/influxdb-cluster) module to deploy a [InfluxDB Enterprise](https://www.influxdata.com/time-series-platform/influxdb/) cluster in [GCP](https://cloud.google.com/). The cluster consists of a Managed Regional Instance Group for both Meta and Data nodes.
+This folder shows an example of Terraform code that uses the [tick-instance-group](https://github.com/gruntwork-io/terraform-google-influx/tree/master/modules/tick-instance-group) module to deploy a [InfluxDB Enterprise](https://www.influxdata.com/time-series-platform/influxdb/) cluster in [GCP](https://cloud.google.com/). The cluster consists of a Managed Regional Instance Group for both Meta and Data nodes.
 
 This example also deploys an Internal TCP Load Balancer in front of the InfluxDB cluster. Note that as the load balancer is internal, it is not accessible from the public internet. 
 

--- a/examples/influxdb-enterprise/README.md
+++ b/examples/influxdb-enterprise/README.md
@@ -1,6 +1,6 @@
 # InfluxDB Enterprise Example
 
-This folder shows an example of Terraform code that uses the [influxdb-cluster](https://github.com/gruntwork-io/terraform-google-influx/tree/master/modules/influxdb-cluster) module to deploy a [InfluxDB Enterprise](https://www.influxdata.com/time-series-platform/influxdb/) cluster in [GCP](https://cloud.google.com/). The cluster consists of a Managed Regional Instance Group for both Meta and Data nodes.
+This folder shows an example of Terraform code that uses the [influxdb-cluster](https://github.com/gruntwork-io/terraform-aws-influx/tree/master/modules/influxdb-cluster) module to deploy a [InfluxDB Enterprise](https://www.influxdata.com/time-series-platform/influxdb/) cluster in [GCP](https://cloud.google.com/). The cluster consists of a Managed Regional Instance Group for both Meta and Data nodes.
 
 This example also deploys an Internal TCP Load Balancer in front of the InfluxDB cluster. Note that as the load balancer is internal, it is not accessible from the public internet. 
 
@@ -31,4 +31,4 @@ You can get the public IP address of one of the Data nodes using one of the foll
   * `INSTANCE_URI=$(gcloud compute instance-groups managed list-instances $IGM --limit=1 --uri)`
   * `gcloud compute instances describe $INSTANCE_URI --format='get(networkInterfaces[0].accessConfigs[0].natIP)'`
 
-Check out [How do you connect to the InfluxDB cluster](https://github.com/gruntwork-io/terraform-google-influx/tree/master/modules/influxdb-cluster#how-do-you-connect-to-the-influxdb-cluster) documentation for further details.
+Check out [How do you connect to the InfluxDB cluster](https://github.com/gruntwork-io/terraform-aws-influx/tree/master/modules/influxdb-cluster#how-do-you-connect-to-the-influxdb-cluster) documentation for further details.

--- a/examples/influxdb-oss/README.md
+++ b/examples/influxdb-oss/README.md
@@ -7,7 +7,7 @@ This example also deploys an Internal TCP Load Balancer in front of the InfluxDB
 You will need to create a [custom image](https://cloud.google.com/compute/docs/images/create-delete-deprecate-private-images) for [Compute Engine](https://cloud.google.com/compute/) that has [InfluxDB OSS](https://www.influxdata.com/products/influxdb-overview/) installed, which you can do using the [influxdb-oss machine image example](https://github.com/gruntwork-io/terraform-google-influx/tree/master/examples/machine-images/influxdb-oss). 
 
 To see an example of InfluxDB Enterprise deployed across separate clusters, see the [influxdb-enterprise
-example](https://github.com/gruntwork-io/terraform-google-influx/tree/master/examples/influxdb-enterprise). For more info on how the InfluxDB cluster works, check out the [influxdb-cluster](https://github.com/gruntwork-io/terraform-aws-influx/tree/master/modules/influxdb-cluster) documentation.
+example](https://github.com/gruntwork-io/terraform-google-influx/tree/master/examples/influxdb-enterprise). For more info on how the InfluxDB cluster works, check out the [documentation at the root of the repository](https://github.com/gruntwork-io/terraform-google-influx).
 
 ## Quick start
 

--- a/examples/influxdb-oss/README.md
+++ b/examples/influxdb-oss/README.md
@@ -7,7 +7,7 @@ This example also deploys an Internal TCP Load Balancer in front of the InfluxDB
 You will need to create a [custom image](https://cloud.google.com/compute/docs/images/create-delete-deprecate-private-images) for [Compute Engine](https://cloud.google.com/compute/) that has [InfluxDB OSS](https://www.influxdata.com/products/influxdb-overview/) installed, which you can do using the [influxdb-oss machine image example](https://github.com/gruntwork-io/terraform-google-influx/tree/master/examples/machine-images/influxdb-oss). 
 
 To see an example of InfluxDB Enterprise deployed across separate clusters, see the [influxdb-enterprise
-example](https://github.com/gruntwork-io/terraform-google-influx/tree/master/examples/influxdb-enterprise). For more info on how the InfluxDB cluster works, check out the [influxdb-cluster](https://github.com/gruntwork-io/terraform-google-influx/tree/master/modules/influxdb-cluster) documentation.
+example](https://github.com/gruntwork-io/terraform-google-influx/tree/master/examples/influxdb-enterprise). For more info on how the InfluxDB cluster works, check out the [influxdb-cluster](https://github.com/gruntwork-io/terraform-aws-influx/tree/master/modules/influxdb-cluster) documentation.
 
 ## Quick start
 
@@ -32,4 +32,4 @@ You can get the public IP address using one of the following methods:
   * `INSTANCE_URI=$(gcloud compute instance-groups managed list-instances $IGM --limit=1 --uri)`
   * `gcloud compute instances describe $INSTANCE_URI --format='get(networkInterfaces[0].accessConfigs[0].natIP)'`
 
-Check out [How do you connect to the InfluxDB cluster](https://github.com/gruntwork-io/terraform-google-influx/tree/master/modules/influxdb-cluster#how-do-you-connect-to-the-influxdb-cluster) documentation for further details.
+Check out [How do you connect to the InfluxDB cluster](https://github.com/gruntwork-io/terraform-aws-influx/tree/master/modules/influxdb-cluster#how-do-you-connect-to-the-influxdb-cluster) documentation for further details.

--- a/examples/tick-enterprise-standalone/README.md
+++ b/examples/tick-enterprise-standalone/README.md
@@ -31,6 +31,6 @@ You can get the instance public IP address using one of the following methods:
   * `INSTANCE_URI=$(gcloud compute instance-groups managed list-instances $IGM --limit=1 --uri)`
   * `gcloud compute instances describe $INSTANCE_URI --format='get(networkInterfaces[0].accessConfigs[0].natIP)'`
 
-Check out [How do you connect to the InfluxDB cluster](https://github.com/gruntwork-io/terraform-google-influx/tree/master/modules/influxdb-cluster#how-do-you-connect-to-the-influxdb-cluster) documentation for further details.
+Check out [How do you connect to the InfluxDB cluster](https://github.com/gruntwork-io/terraform-aws-influx/tree/master/modules/influxdb-cluster#how-do-you-connect-to-the-influxdb-cluster) documentation for further details.
 
 To connect to Chronograf, use the steps described above, replacing `influxdb_instance_group_manager` with `chronograf_instance_group_manager`.

--- a/examples/tick-oss-colocated/README.md
+++ b/examples/tick-oss-colocated/README.md
@@ -25,4 +25,4 @@ You can get the public IP address of the instance using one of the following met
    - `INSTANCE_URI=$(gcloud compute instance-groups managed list-instances $IGM --limit=1 --uri)`
    - `gcloud compute instances describe $INSTANCE_URI --format='get(networkInterfaces[0].accessConfigs[0].natIP)'`
 
-Check out [How do you connect to the InfluxDB cluster](https://github.com/gruntwork-io/terraform-google-influx/tree/master/modules/influxdb-cluster#how-do-you-connect-to-the-influxdb-cluster) documentation for further details.
+Check out [How do you connect to the InfluxDB cluster](https://github.com/gruntwork-io/terraform-aws-influx/tree/master/modules/influxdb-cluster#how-do-you-connect-to-the-influxdb-cluster) documentation for further details.

--- a/modules/install-chronograf/README.md
+++ b/modules/install-chronograf/README.md
@@ -29,8 +29,7 @@ The `install-chronograf` script will install the Chronograf binary as well as it
 
 We recommend running the `install-chronograf` script as part of a [Packer](https://www.packer.io/) template to 
 create a Chronograf [custom image](https://cloud.google.com/compute/docs/images/create-delete-deprecate-private-images) for [Compute Engine](https://cloud.google.com/compute/).
-You can then deploy the image across an instance group using the [managed-instance-group 
-module](https://github.com/gruntwork-io/terraform-google-influx/tree/master/modules/managed-instance-group) (see the 
+You can then deploy the image across an instance group (see the 
 [examples folder](https://github.com/gruntwork-io/terraform-google-influx/tree/master/examples) for fully-working sample code).
 
 ## Command line Arguments

--- a/modules/install-influxdb/README.md
+++ b/modules/install-influxdb/README.md
@@ -1,6 +1,6 @@
 # InfluxDB Install Script
 
-This folder contains a script for installing InfluxDB and its dependencies. Use this script to create an InfluxDB [Compute Image](https://cloud.google.com/compute/docs/images) that can be deployed in [GCP](https://cloud.google.com/gcp/) across an [Instance Group](https://cloud.google.com/compute/docs/instance-groups/).
+This folder contains a script for installing InfluxDB and its dependencies. Use this script to create an InfluxDB [Compute Image](https://cloud.google.com/compute/docs/images) that can be deployed in [GCP](https://cloud.google.com/gcp/) across an [Instance Group](https://cloud.google.com/compute/docs/instance-groups/) using the [tick-instance-group module](https://github.com/gruntwork-io/terraform-google-influx/tree/master/modules/tick-instance-group).
 
 You can install either OSS or Enterprise version of InfluxDB using the `--distribution` argument. Allowed values are `oss` and `enterprise`.
 

--- a/modules/install-influxdb/README.md
+++ b/modules/install-influxdb/README.md
@@ -27,7 +27,7 @@ Checkout the [releases](https://github.com/gruntwork-io/terraform-google-influx/
 
 Depending on `--distribution`, the `install-influxdb` script will install either the OSS binaries or both InfluxDB meta and data binaries, as well as their dependencies. The [run-influxdb](../run-influxdb) script determines whether to startup either as a standalone, meta or data node.
 
-We recommend running the `install-influxdb` script as part of a [Packer](https://www.packer.io/) template to create an InfluxDB [Compute Image](https://cloud.google.com/compute/docs/images). You can then deploy the Image across an [Instance Group](https://cloud.google.com/compute/docs/instance-groups/) (see the [examples folder](../../examples) for fully-working sample code).
+We recommend running the `install-influxdb` script as part of a [Packer](https://www.packer.io/) template to create an InfluxDB [Compute Image](https://cloud.google.com/compute/docs/images). You can then deploy the Image across an [Instance Group](https://cloud.google.com/compute/docs/instance-groups/) using the [tick-instance-group module](https://github.com/gruntwork-io/terraform-google-influx/tree/master/modules/tick-instance-group) (see the [examples folder](../../examples) for fully-working sample code).
 
 ## Command line Arguments
 
@@ -66,4 +66,3 @@ The `install-influxdb` script does the following:
 
 1. Installs the InfluxDB binaries
 1. Replaces default config files with specified templated config files.
-

--- a/modules/install-influxdb/README.md
+++ b/modules/install-influxdb/README.md
@@ -1,6 +1,6 @@
 # InfluxDB Install Script
 
-This folder contains a script for installing InfluxDB and its dependencies. Use this script to create an InfluxDB [Compute Image](https://cloud.google.com/compute/docs/images) that can be deployed in [GCP](https://cloud.google.com/gcp/) across an [Instance Group](https://cloud.google.com/compute/docs/instance-groups/) using the [influxdb-cluster module](../influxdb-cluster).
+This folder contains a script for installing InfluxDB and its dependencies. Use this script to create an InfluxDB [Compute Image](https://cloud.google.com/compute/docs/images) that can be deployed in [GCP](https://cloud.google.com/gcp/) across an [Instance Group](https://cloud.google.com/compute/docs/instance-groups/).
 
 You can install either OSS or Enterprise version of InfluxDB using the `--distribution` argument. Allowed values are `oss` and `enterprise`.
 
@@ -25,9 +25,9 @@ gruntwork-install \
 
 Checkout the [releases](https://github.com/gruntwork-io/terraform-google-influx/releases) to find the latest version.
 
-Depending on `--distribution`, the `install-influxdb` script will install either the OSS binaries or both InfluxDB meta and data binaries, as well as their dependencies. The [run-influxdb](../run-influxdb/bin) script determines whether to startup either as a standalone, meta or data node.
+Depending on `--distribution`, the `install-influxdb` script will install either the OSS binaries or both InfluxDB meta and data binaries, as well as their dependencies. The [run-influxdb](../run-influxdb) script determines whether to startup either as a standalone, meta or data node.
 
-We recommend running the `install-influxdb` script as part of a [Packer](https://www.packer.io/) template to create an InfluxDB [Compute Image](https://cloud.google.com/compute/docs/images). You can then deploy the Image across an [Instance Group](https://cloud.google.com/compute/docs/instance-groups/) using the [influxdb-cluster module](../influxdb-cluster) (see the [examples folder](../../examples) for fully-working sample code).
+We recommend running the `install-influxdb` script as part of a [Packer](https://www.packer.io/) template to create an InfluxDB [Compute Image](https://cloud.google.com/compute/docs/images). You can then deploy the Image across an [Instance Group](https://cloud.google.com/compute/docs/instance-groups/) (see the [examples folder](../../examples) for fully-working sample code).
 
 ## Command line Arguments
 


### PR DESCRIPTION
fix broken links

I linked to [aws influxdb-cluster](https://github.com/gruntwork-io/terraform-aws-influx/tree/master/modules/influxdb-cluster) as this repo does not have influxdb-cluster. I'm guessing I should take it out completely but I'll like to be certain.